### PR TITLE
Fix code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,10 @@ func main() {
 	// If the input string represents a number that is too large for the target integer type, it can cause unexpected behavior or security issues.
 	// Best practice is to use appropriate integer types with sufficient range and perform proper error handling and input validation.
 	val := resp.Request.URL.Query().Get("val")
-	num, _ := strconv.Atoi(val)
+	num, err := strconv.ParseInt(val, 10, 16)
+	if err != nil {
+		log.Fatal(err)
+	}
 	var intVal int16 = int16(num)
 	fmt.Println(intVal)
 


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Go_1/security/code-scanning/4](https://github.com/Brook-5686/Go_1/security/code-scanning/4)

To fix the problem, we need to ensure that the integer value parsed from the string does not exceed the bounds of the `int16` type before performing the conversion. This can be achieved by using `strconv.ParseInt` with a specified bit size of 16, which will handle the bounds checking for us.

1. Replace the use of `strconv.Atoi` with `strconv.ParseInt`, specifying a bit size of 16.
2. Handle the error returned by `strconv.ParseInt` to ensure that invalid input is properly managed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
