### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,9 +42,15 @@ func main() {
 	// Vulnerability: Using user-supplied input directly as a file path can lead to path traversal vulnerabilities.
 	// An attacker can craft a malicious path to access files outside the intended directory.
 	// Best practice is to validate and sanitize user input before using it as a file path.
+	const safeDir = "/home/user/"
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		filePath := r.URL.Query().Get("path")
-		data, err := os.ReadFile(filePath)
+		absPath, err := filepath.Abs(filepath.Join(safeDir, filePath))
+		if err != nil || !strings.HasPrefix(absPath, safeDir) {
+			http.Error(w, "Invalid file path", http.StatusBadRequest)
+			return
+		}
+		data, err := os.ReadFile(absPath)
 		if err != nil {
 			http.Error(w, "Error reading file", http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Fixes [https://github.com/Brook-5686/Go_1/security/code-scanning/2](https://github.com/Brook-5686/Go_1/security/code-scanning/2)

To fix the problem, we need to ensure that the user-provided file path is validated and sanitized before it is used. The best way to do this is to ensure that the resolved path is within a specific safe directory. This can be achieved by resolving the input path with respect to the safe directory and then checking that the resulting path is still within it.

1. Define a constant for the safe directory.
2. Resolve the user-provided path with respect to the safe directory.
3. Check that the resolved path is within the safe directory.
4. If the path is valid, proceed to read the file; otherwise, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
